### PR TITLE
Fix Student Show Test / Push Forward Reset Password

### DIFF
--- a/app/controllers/send_reset_links_controller.rb
+++ b/app/controllers/send_reset_links_controller.rb
@@ -4,10 +4,10 @@ class SendResetLinksController < ApplicationController
   end
 
   def create
-    binding.pry
-    @user = User.find_by(email: reset_params)
+    @user = Teacher.find_by(email: reset_params[:email])
     if @user
-      @user.create_reset_digest
+      binding.pry
+      @user.create_reset_digest # Failing here
       @user.send_password_reset_email
       flash[:notice] = "Email has been sent with password reset instructions"
       redirect_to login_path

--- a/app/controllers/students_controller.rb
+++ b/app/controllers/students_controller.rb
@@ -1,7 +1,7 @@
 class StudentsController < ApplicationController
   def show
     render locals: {
-      facade: StudentsFacade.new(params[:id], params[:course_id])
+      facade: StudentFacade.new(params[:id], params[:course_id])
     }
   end
 end

--- a/app/facades/student_facade.rb
+++ b/app/facades/student_facade.rb
@@ -1,4 +1,4 @@
-class StudentsFacade
+class StudentFacade
   attr_reader :id, :course
   def initialize(id, course_id)
     @id = id

--- a/app/facades/student_facade.rb
+++ b/app/facades/student_facade.rb
@@ -19,6 +19,6 @@ class StudentFacade
   def statistics
     ["Present: #{student.percent_present(@course)}%",
       "Absent: #{student.percent_absent(@course)}%",
-      "Total Absences: #{student.total_absences(@course)}"]
+      "Total Absences: #{student.total_absences(@course)} days"]
   end
 end

--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -11,20 +11,23 @@ class Student < ApplicationRecord
     today.first ? today.first.attendance : "No Attendance Today"
   end
 
-  def percent_present(course)
+  def percent_present(course = nil)
     100.0 - percent_absent(course)
   end
 
-  def percent_absent(course)
-    course_attendance = attendances.where(course_id: course.id)
-    total_days = course_attendance.count
+  def percent_absent(course = nil)
+    total_days = course_attendance(course).count
     (total_absences(course) * 100.0 / total_days).round(1)
   end
 
-  def total_absences(course)
-    course_attendance = attendances.where(course_id: course.id)
+  def total_absences(course = nil)
     options = ["absent", "absent_with_response"]
-    course_attendance.where(attendance: options, course_id: course.id).count
+    course_attendance(course).where(attendance: options).count
+  end
+
+  def course_attendance(course)
+    return attendances.where(course: course) if course
+    attendances
   end
 
   def self.random_groups(count)

--- a/spec/features/students/show_page_for_teachers_spec.rb
+++ b/spec/features/students/show_page_for_teachers_spec.rb
@@ -24,7 +24,7 @@ describe "As a logged-in Teacher" do
       @student.attendances.create(course_id: @course2.id, created_at: "2019-05-26 02:00:00", attendance: "absent")
 
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@teacher)
-      visit student_path(@student)
+      visit student_path(@student, {course_id: @course.id})
     end
 
     it "should have student name and id" do

--- a/spec/features/teachers/forgot_password_spec.rb
+++ b/spec/features/teachers/forgot_password_spec.rb
@@ -3,9 +3,9 @@ require "rails_helper"
 describe "As a forgetful teacher, who forgot their password" do
   describe "when I reach the welcome page" do
     it "allows me to send an email to reset my password" do
-      @teacher = create(:teacher, reset_token: "asdf", reset_sent_at: DateTime.now)
+      @teacher = create(:teacher) #, reset_token: "asdf", reset_sent_at: DateTime.now)
       visit welcome_path
-      click_link "Forgot password?"
+      click_link "Forgot Password?"
       expect(current_path).to eq(send_reset_link_path)
 
       fill_in 'Email', with: @teacher.email

--- a/spec/models/student_spec.rb
+++ b/spec/models/student_spec.rb
@@ -53,34 +53,35 @@ describe Student, type: :model do
         @student.courses << Course.first
         @student.courses << Course.last
 
-        @student.attendances.create(course_id: @course.id, created_at: "2019-05-26 02:00:00", attendance: "present")
-        @student.attendances.create(course_id: @course.id, created_at: "2019-05-26 02:00:00", attendance: "absent")
-        @student.attendances.create(course_id: @course.id, created_at: "2019-05-26 02:00:00", attendance: "present")
-        @student.attendances.create(course_id: @course.id, created_at: "2019-05-26 02:00:00", attendance: "present")
-        @student.attendances.create(course_id: @course.id, created_at: "2019-05-26 02:00:00", attendance: "absent")
-        @student.attendances.create(course_id: @course.id, created_at: "2019-05-26 02:00:00", attendance: "present")
-        @student.attendances.create(course_id: @course.id, created_at: "2019-05-26 02:00:00", attendance: "present")
-        @student.attendances.create(course_id: @course.id, created_at: "2019-05-26 02:00:00", attendance: "present")
-        @student.attendances.create(course_id: @course.id, created_at: "2019-05-26 02:00:00", attendance: "present")
-        @student.attendances.create(course_id: @course.id, created_at: "2019-05-26 02:00:00", attendance: "present")
-        @student.attendances.create(course_id: @course2.id, created_at: "2019-05-26 02:00:00", attendance: "absent")
+        8.times { @student.attendances.create(course: @course, attendance: "present") }
+        2.times { @student.attendances.create(course: @course, attendance: "absent") }
+
+        6.times { @student.attendances.create(course: @course2, attendance: "present") }
+        4.times { @student.attendances.create(course: @course2, attendance: "absent") }
+
       end
 
       describe "percent_present" do
         it "returns the percent of days present for a student" do
           expect(@student.percent_present(@course)).to eq(80.0)
+          expect(@student.percent_present(@course2)).to eq(60.0)
+          expect(@student.percent_present).to eq(70.0)
         end
       end
 
       describe "percent_absent" do
         it "returns the percent of days absent for a student" do
           expect(@student.percent_absent(@course)).to eq(20.0)
+          expect(@student.percent_absent(@course2)).to eq(40.0)
+          expect(@student.percent_absent).to eq(30.0)
         end
       end
 
       describe "total_absences" do
         it "returns the number of days absent for a student" do
           expect(@student.total_absences(@course)).to eq(2)
+          expect(@student.total_absences(@course2)).to eq(4)
+          expect(@student.total_absences).to eq(6)
         end
       end
     end


### PR DESCRIPTION
Address some errors in testing the student show page
Cleans up some of the testing done of sending the reset link email